### PR TITLE
Interfaces change to support bank-card payments

### DIFF
--- a/interfaces/bank_session_token_provider.yaml
+++ b/interfaces/bank_session_token_provider.yaml
@@ -1,0 +1,11 @@
+description: >-
+  Provides the token that can be used to uniquely identify the session in the
+  bank statement.
+cmds:
+  getBankSessionToken:
+    description: >-
+      Returns the token that.
+    result: 
+      description: token
+      type: object
+      $ref: bank_transaction#/BankSessionToken

--- a/interfaces/bank_transction_summary_provider.yaml
+++ b/interfaces/bank_transction_summary_provider.yaml
@@ -1,0 +1,10 @@
+description: >-
+  Provides information of the session that was commited to the bank.
+  This date may be needed for accounting perposes.
+vars:
+  bank_transaction_summary:
+    description: >-
+      Summary of a bank transaction. Depends on bank and the backend. Therefore
+      it's mostly opque data at the moment.
+    type: object
+    $ref: bank_transaction#/BankTransactionSummary

--- a/interfaces/session_cost_calculator.yaml
+++ b/interfaces/session_cost_calculator.yaml
@@ -1,0 +1,11 @@
+description: >-
+  This interface publishes the running or finished session costs. This interface
+  provides cost of one session. If we have more than one outlet, we need to 
+  instantiate this interface for each outlet.
+vars:
+  session_cost:
+    description: >-
+      Session cost object containing the total cost of the session and a list
+      of chunks
+    type: object
+    $ref: session_cost#/SessionCost

--- a/types/authorization.yaml
+++ b/types/authorization.yaml
@@ -137,6 +137,7 @@ types:
       - RFID
       - Autocharge
       - PlugAndCharge
+      - BankCard
   IdTokenType:
     description: >-
       IdTokenType of the provided token

--- a/types/bank_transaction.yaml
+++ b/types/bank_transaction.yaml
@@ -1,0 +1,34 @@
+description: >-
+  Types needed for bookkeeping bank transactions
+types:
+  BankSessionToken:
+    description: >-
+      In Germany (an probably other countries) we have to provide a token
+      to the bank, so that customer can identify the transaction from their
+      bank statement. This token can be used to download the invoices.
+    type: object
+    additionalProperties: false
+    properties:
+      token:
+        description: >-
+          Arbitrary token string. Typically short string that is printable case insensitive
+          ascii.
+        type: string
+  BankTransactionSummary:
+    description: >-
+      Summary of a bank transaction. Depends on bank and the backend. Therefore
+      it's mostly opque data at the moment.
+    type: object
+    additionalProperties: false
+    properties:
+      session_token:
+        description: >-
+          Token to identify the session. This token can be used to download the
+          invoices.
+        type: object
+        $ref: bank_transaction#/BankSessionToken
+      transaction_data:
+        description: >-
+          Arbitrary data that is needed to identify the transaction. This is
+          mostly opque data at the moment.
+        type: string

--- a/types/session_price.yaml
+++ b/types/session_price.yaml
@@ -1,0 +1,73 @@
+description: Types to provide the session price
+types:
+  SessionCostChunk:
+    description: >-
+      A chunk of the session cost. The total cost of the session is the sum of
+      all chunks.
+    type: object
+    additionalProperties: false
+    properties:
+      timestamp_from:
+        description: >-
+          Absolute timestamp for the start of this chunk in RFC3339 UTC format
+        type: string
+        format: date-time
+      timestamp_to:
+        description: >-
+          Absolute timestamp for the end of this chunk in RFC3339 UTC format
+        type: string
+        format: date-time
+      cost_energy:
+        description: >-
+          Cost of the energy consumed during this chunk in the currency
+          specified in the session price
+        type: number
+      cost_time:
+        description: >-
+          Cost of the time spent during this chunk in the currency specified
+          in the session price
+        type: number
+  SessionStatus:
+    description: >-
+      Session status enum. Session can be running or finished. Costs of the
+      running session are not final and can change.
+    type: string
+    enum:
+      - running
+      - finished
+  SessionCost:
+    description: >-
+      Session cost object containing the total cost of the session and a list
+      of chunks
+    type: object
+    additionalProperties: false
+    required:
+      - total_cost
+      - currency
+      - cost_chunks
+    properties:
+      id_tag:
+        description: The id tag assigned to this transaction
+        type: object
+        $ref: /authorization#/ProvidedIdToken
+      total_cost:
+        description: >-
+          Total cost of the session in the currency specified in the session
+          price
+        type: number
+      currency:
+        description: >-
+          Currency in 3 digit ISO 4217. This is the currency used for all
+          cost values in this object
+        type: string
+        minLength: 3
+        maxLength: 3
+      cost_chunks:
+        description: >-
+          List of cost chunks. The total cost of the session is the sum of
+          all chunks.
+        type: array
+        items:
+          description: One chunk of the session cost
+          type: object
+          $ref: /session_price#/SessionCostChunk  


### PR DESCRIPTION
# Bank Card Payment

# Objectives

- Provide types and interfaces for payment terminals

## Supported Use-Cases

### Normal Flow

- Payment made with credit card.
- Normal(few hours) charging session happens.
- Once session is finished, the payment terminal commits bank transaction
- Backend communication module receives the information about the bank transaction and sends it to the backend

### Interrupted charging

- Customer pays with the card
- The charging never starts
- After timeout bank transaction is cancelled (maybe it should be communicated to the backend as well?)

### Too expensive session

depending on the bank/terminal there could be a limit on maximum transaction amount. (e.g. if the flow is: reserve some amount, once transaction finished, do a partial return).

- Customer pays with a card
- Customer charges a lot of electricity over some reasonably long time
- Once current session costs are at the limit, session is stopped
- Transaction is committed to bank

### To long session

Depending on the bank the reservation shouldn’t be held for more the few days. And similar to previous case, the session should be interrupted if transaction time is at the maximum limit.

# Proposed solution

Introduce new interfaces

- **`session_cost_calculator`**. → This interface publishes a variables with the session cost for corresponding evse-manager. The module, that implements the interface supposed to sbuscribe to the evse-manager, to get the consumed electricity and time. Depending on the system, the tariff source could be stored locally or loaded from the energy_price_information.yaml, or from other interface. This is not covered in this proposal.
- `bank_session_token_provider` → This interface allows to generate or request from the backend a token to be used in bank transaction (as sort of “Verwendungszweck”).
- `bank_transaction_summary` → This interface supposed to be implemented by the payment terminal module. It provides accounting information.

## How does it work

Payment terminal module implements `auth_token_provider` interface. If user pays with a bank card, then payment terminal pre-authorizes transaction in the bank (potentially reserves money).

And if pre-authorization was successful, payment terminal generates the AuthToken, and publishes it. To distinguish from other tokens, a new `AuthorizationType::BankCard`is used.

The token is processed by Auth module as usually. This includes passing to validators, validators typically always approve the token. 

A module that implements `session_cost_calculator`publishes the session cost. And the payment terminal subscribes to it. Once session is finished (can be detected by status filed in the session cost) payment terminal commits it. Payment terminal stores all the issues bank-card tokens to match bank transactions with charging sessions.